### PR TITLE
Use log instead of fmt, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # apialerts-go
+
+Golang client for [apialerts.com](https://apialerts.com/)
+
+## Installation
+
+```bash
+go get github.com/apialerts/apialerts-go
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"log"
+
+	"github.com/apialerts/apialerts-go"
+)
+
+func main() {
+	client := apialerts.ApiAlertsClient()
+	client.SetApiKey("API_KEY_GOES_HERE")
+	err := client.Send("Golang Test Message", []string{"Golang is better than kotlin"}, "https://github.com/apialerts/")
+	if err != nil {
+		log.Println("Error:", err)
+	}
+}
+```
+
+

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
+	"log"
 	"net/http"
 	"os"
 )
@@ -33,8 +33,8 @@ func (client *Client) Send(message string, tags []string, link string) error {
 
 	payload := map[string]interface{}{
 		"message": message,
-		"tags": tags,
-		"link": link,
+		"tags":    tags,
+		"link":    link,
 	}
 
 	payloadBytes, err := json.Marshal(payload)
@@ -49,49 +49,37 @@ func (client *Client) Send(message string, tags []string, link string) error {
 		return err
 	}
 
-	req.Header.Set("Authorization", "Bearer " + client.apiKey)
+	req.Header.Set("Authorization", "Bearer "+client.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Integration", "golang")
 	req.Header.Set("X-Version", "1.0.0")
 
 	httpClient := &http.Client{}
 
-	resp, err :=  httpClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
-		case http.StatusOK:
-			var data map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-				return err
-			}
-			fmt.Printf("✓ (apialerts.com) Alert sent to %v successfully.", data["project"])
-			return nil
-		case http.StatusBadRequest:
-			return errors.New("bad request")
-		case http.StatusUnauthorized:
-			return errors.New("unauthorized")
-		case http.StatusForbidden:
-			return errors.New("forbidden")
-		case http.StatusTooManyRequests:
-			return errors.New("rate limit exceeded")
-		default:
-			return errors.New("unknown error")
+	case http.StatusOK:
+		var data map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return err
+		}
+		log.Printf("✓ (apialerts.com) Alert sent to %v successfully.", data["project"])
+		return nil
+	case http.StatusBadRequest:
+		return errors.New("bad request")
+	case http.StatusUnauthorized:
+		return errors.New("unauthorized")
+	case http.StatusForbidden:
+		return errors.New("forbidden")
+	case http.StatusTooManyRequests:
+		return errors.New("rate limit exceeded")
+	default:
+		return errors.New("unknown error")
 	}
 
 }
-
-// THIS IS SOME EXAMPLE CODE
-/*
-func main() {
-	client := ApiAlertsClient()
-	client.SetApiKey("API_KEY_GOES_HERE")
-	err := client.Send("Golang Test Message", []string{"Golang is better than kotlin"}, "https://github.com/apialerts/")
-	if err != nil {
-		fmt.Println("Error:", err)
-	}
-}
-*/


### PR DESCRIPTION
My linter got a hold of it, no significant changes despite appearances to the contrary.

Only real changes are adding the example to the readme and using the built in logger instead of fmt. 