### PR TITLE
Singleton support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ event := apialerts.Event {
     Link:    "http://example.com",     // optional
 }
 
-client.Send(event)
+apialerts.Send(event)
 ```
 
 The apialerts.sendAsync() methods are also available if you need to wait for a successful execution. However, the send() functions are generally always preferred.
@@ -51,7 +51,7 @@ The apialerts.sendAsync() methods are also available if you need to wait for a s
 You may have the need to talk to different API Alerts workspaces in your application. You can use the SendWithAPIKey() functions to send alerts to override the default apikey for that single send call
 
 ```go
-SendWithApiKey("other_api_key", event)
+apialerts.SendWithApiKey("other_api_key", event)
 ```
 
 ### Feedback & Support

--- a/README.md
+++ b/README.md
@@ -12,76 +12,52 @@ Add the following dependency to your GO application
 go get github.com/apialerts/apialerts-go
 ```
 
-## Usage
+### Initialize the client
 
-### Event structure
+The client is implemented as a singleton, ensuring that only one instance is created and used throughout the application.
+
 ```go
-event := apialerts.Event{
+// Basic initialization with default config
+apialerts.Configure("your-api-key")
+
+// or initialization with custom config
+customConfig := apialerts.Config {
+    Timeout: 45 * time.Second,  // default is 30 seconds
+    Debug:   True,              // default is false
+}
+apialerts.ConfigureWithConfig("test_api_key", customConfig)
+}
+```
+
+### Send Events
+
+You can send alerts by constructing the Event struct and passing it to the Send() function.
+
+```go
+event := apialerts.Event {
     Channel: "test_channel",           // optional, uses the default channel if not provided
     Message: "Test message",           // required
     Tags:    []string{"tag1", "tag2"}, // optional
     Link:    "http://example.com",     // optional
 }
+
+client.Send(event)
 ```
 
+The apialerts.sendAsync() methods are also available if you need to wait for a successful execution. However, the send() functions are generally always preferred.
 
-### Initialize the client 
-```go
-// Custom config can be passed to the client
-customConfig := model.APIAlertsConfig {
-    Logging: true,
-    Timeout: 30 * time.Second,
-    Debug:   false,
-}
+### Send with API Key functions
 
-client := ApiAlertsClientWithConfig("test_api_key", customConfig)
-// or
-client := ApiAlertsClient("test_api_key")
-}
-```
-
-### Send an event
+You may have the need to talk to different API Alerts workspaces in your application. You can use the SendWithAPIKey() functions to send alerts to override the default apikey for that single send call
 
 ```go
-event := model.APIAlertsEvent {
-    Channel: "test_channel",           // optional, uses the default channel if not provided
-    Message: "Test message",
-    Tags:    []string{"tag1", "tag2"}, // optional
-    Link:    "http://example.com",     // optional
-}
-
-err := client.Send(event)
-if err != nil {
-    log.Printf("Error sending message: %v", err)
-}
+SendWithApiKey("other_api_key", event)
 ```
 
-### Send an event with an alternate api key
+### Feedback & Support
 
-```go
-client.SendWithApiKey("other project api key", event)
-```
+If you have any questions or feedback, please create an issue on our GitHub repository. We are always looking to improve our service and would love to hear from you. Thanks for using API Alerts!
 
-
-### Send message asynchronously
-
-Async methods of the Send() function are available in situations (like AWS Lambda) where you need to wait for the event execution. However, using the Send() functions are generally always preferred.
-
-```go
-client.SendAsync(event)
-```
-
-
-### Send message asynchronously with custom config
-
-Custom config can also be applied with a Send event
-
-```go
-func main() {
-    //... client initialization
-    client.SendAsyncWithApiKey("other project api key", event)
-}
-```
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ go get github.com/apialerts/apialerts-go
 
 ### Event structure
 ```go
-event := model.APIAlertsEvent {
+event := apialerts.Event{
     Channel: "test_channel",           // optional, uses the default channel if not provided
     Message: "Test message",           // required
-    Tags   : []string{"tag1", "tag2"}, // optional
-    Link   : "http://example.com",     // optional
+    Tags:    []string{"tag1", "tag2"}, // optional
+    Link:    "http://example.com",     // optional
 }
 ```
 

--- a/apialerts.go
+++ b/apialerts.go
@@ -11,8 +11,8 @@ var (
 )
 
 type Config struct {
-	Timeout time.Duration
-	Debug   bool
+	Timeout time.Duration // Timeout specifies the duration to wait before timing out a request.
+	Debug   bool          // Debug enables or disables debug logging.
 }
 
 var defaultConfig = Config{
@@ -26,34 +26,42 @@ func setupClient(apiKey string, config Config) {
 	})
 }
 
+// Configure initializes the client with the default configuration using the provided API key.
 func Configure(apiKey string) {
 	setupClient(apiKey, defaultConfig)
 }
 
+// ConfigureWithConfig initializes the client with a custom configuration using the provided API key.
 func ConfigureWithConfig(apiKey string, config Config) {
 	setupClient(apiKey, config)
 }
 
+// GetInstance returns the singleton instance of the Client.
 func GetInstance() *Client {
 	return instance
 }
 
+// SetApiKey sets a new API key for the client instance.
 func SetApiKey(apiKey string) {
 	instance.apiKey = apiKey
 }
 
+// Send sends an event asynchronously using the default API key.
 func Send(event Event) {
 	go instance.sendToUrlWithApiKey(ApiUrl, instance.apiKey, event)
 }
 
+// SendAsync sends an event asynchronously using the default API key, waits for the response, and returns an error if any.
 func SendAsync(event Event) error {
 	return instance.sendToUrlWithApiKeyAsync(ApiUrl, instance.apiKey, event)
 }
 
+// SendWithApiKey sends an event asynchronously using the provided API key.
 func SendWithApiKey(apiKey string, event Event) {
 	instance.sendToUrlWithApiKey(ApiUrl, apiKey, event)
 }
 
+// SendWithApiKeyAsync sends an event asynchronously using the provided API key, waits for the response, and returns an error if any.
 func SendWithApiKeyAsync(apiKey string, event Event) error {
 	return instance.sendToUrlWithApiKeyAsync(ApiUrl, apiKey, event)
 }

--- a/apialerts.go
+++ b/apialerts.go
@@ -1,149 +1,63 @@
 package apialerts
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"log"
-	"net/http"
+	"sync"
 	"time"
-
-	"github.com/apialerts/apialerts-go/model"
 )
 
-var defaultConfig = model.APIAlertsConfig{
-	Logging: true,
+var (
+	instance *Client
+	once     sync.Once
+)
+
+type Config struct {
+	Timeout time.Duration
+	Debug   bool
+}
+
+var defaultConfig = Config{
 	Timeout: 30 * time.Second,
 	Debug:   false,
 }
 
-type APIAlertsClient struct {
-	ApiKey string
-	Config model.APIAlertsConfig
+func setupClient(apiKey string, config Config) {
+	once.Do(func() {
+		instance = initializeClient(apiKey, config)
+	})
 }
 
-func ApiAlertsClientWithConfig(apiKey string, config model.APIAlertsConfig) *APIAlertsClient {
-	return &APIAlertsClient{
-		ApiKey: apiKey,
-		Config: config,
-	}
+func Configure(apiKey string) {
+	setupClient(apiKey, defaultConfig)
 }
 
-func ApiAlertsClient(apiKey string) *APIAlertsClient {
-	return ApiAlertsClientWithConfig(apiKey, defaultConfig)
+func ConfigureWithConfig(apiKey string, config Config) {
+	setupClient(apiKey, config)
 }
 
-func (client *APIAlertsClient) SetApiKey(apiKey string) {
-	client.ApiKey = apiKey
+func SetApiKey(apiKey string) {
+	instance.apiKey = apiKey
 }
 
-func (client *APIAlertsClient) sendToUrlWithApiKey(
-	url string,
-	apiKey string,
-	event model.APIAlertsEvent,
-) error {
-	if apiKey == "" {
-		return errors.New("x (apialerts.com) Error: api key is missing, use SetApiKey() to set it")
-	}
-
-	if event.Message == "" {
-		return errors.New("x (apialerts.com) Error: message is required")
-	}
-
-	payloadBytes, err := json.Marshal(event)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payloadBytes))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Integration", IntegrationName)
-	req.Header.Set("X-Version", IntegrationVersion)
-
-	httpClient := &http.Client{}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var data map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-			return err
-		}
-		if client.Config.Logging {
-			log.Printf("✓ (apialerts.com) Alert sent to %v (%v) successfully.", data["workspace"], data["channel"])
-		}
-		return nil
-	case http.StatusBadRequest:
-		return errors.New("x (apialerts.com) Error: bad request")
-	case http.StatusUnauthorized:
-		return errors.New("x (apialerts.com) Error: unauthorized")
-	case http.StatusForbidden:
-		return errors.New("x (apialerts.com) Error: forbidden")
-	case http.StatusTooManyRequests:
-		return errors.New("x (apialerts.com) Error: rate limit exceeded")
-	default:
-		return errors.New("x (apialerts.com) Error: unknown error")
-	}
+func Send(event Event) {
+	go sendToUrlWithApiKey(ApiUrl, instance.apiKey, event)
 }
 
-func (client *APIAlertsClient) SendWithApiKey(apiKey string, event model.APIAlertsEvent) error {
-	return client.sendToUrlWithApiKey(ApiUrl, apiKey, event)
+func SendAsync(event Event) error {
+	return sendToUrlWithApiKeyAsync(ApiUrl, instance.apiKey, event)
 }
 
-func (client *APIAlertsClient) SendAsyncWithApiKey(apiKey string, event model.APIAlertsEvent) {
-	if client.Config.Debug {
-		errChan := make(chan error, 1)
-		go func() {
-			errChan <- client.SendWithApiKey(apiKey, event)
-		}()
-
-		select {
-		case err := <-errChan:
-			if err != nil {
-				log.Printf("x (apialerts.com) Error: %v", err)
-			}
-		case <-time.After(30 * time.Second):
-			log.Println("x (apialerts.com) Error: Send operation timed out")
-		}
-	} else {
-		go func() {
-			_ = client.SendWithApiKey(apiKey, event)
-		}()
-	}
+func SendWithApiKey(apiKey string, event Event) {
+	sendToUrlWithApiKey(ApiUrl, apiKey, event)
 }
 
-func (client *APIAlertsClient) SendAsync(event model.APIAlertsEvent) {
-	if client.Config.Debug {
-		errChan := make(chan error, 1)
-		go func() {
-			errChan <- client.Send(event)
-		}()
-
-		select {
-		case err := <-errChan:
-			if err != nil {
-				log.Printf("x (apialerts.com) Error: %v", err)
-			}
-		case <-time.After(client.Config.Timeout):
-			log.Println("x (apialerts.com) Error: Send operation timed out")
-		}
-	} else {
-		go func() {
-			_ = client.Send(event)
-		}()
-	}
+func SendWithApiKeyAsync(apiKey string, event Event) error {
+	return sendToUrlWithApiKeyAsync(ApiUrl, apiKey, event)
 }
 
-func (client *APIAlertsClient) Send(event model.APIAlertsEvent) error {
-	return client.SendWithApiKey(client.ApiKey, event)
+func sendToUrlWithApiKey(url string, apiKey string, event Event) {
+	instance.sendToUrlWithApiKey(url, apiKey, event)
+}
+
+func sendToUrlWithApiKeyAsync(url string, apiKey string, event Event) error {
+	return instance.sendToUrlWithApiKeyAsync(url, apiKey, event)
 }

--- a/apialerts.go
+++ b/apialerts.go
@@ -34,30 +34,26 @@ func ConfigureWithConfig(apiKey string, config Config) {
 	setupClient(apiKey, config)
 }
 
+func GetInstance() *Client {
+	return instance
+}
+
 func SetApiKey(apiKey string) {
 	instance.apiKey = apiKey
 }
 
 func Send(event Event) {
-	go sendToUrlWithApiKey(ApiUrl, instance.apiKey, event)
+	go instance.sendToUrlWithApiKey(ApiUrl, instance.apiKey, event)
 }
 
 func SendAsync(event Event) error {
-	return sendToUrlWithApiKeyAsync(ApiUrl, instance.apiKey, event)
+	return instance.sendToUrlWithApiKeyAsync(ApiUrl, instance.apiKey, event)
 }
 
 func SendWithApiKey(apiKey string, event Event) {
-	sendToUrlWithApiKey(ApiUrl, apiKey, event)
+	instance.sendToUrlWithApiKey(ApiUrl, apiKey, event)
 }
 
 func SendWithApiKeyAsync(apiKey string, event Event) error {
-	return sendToUrlWithApiKeyAsync(ApiUrl, apiKey, event)
-}
-
-func sendToUrlWithApiKey(url string, apiKey string, event Event) {
-	instance.sendToUrlWithApiKey(url, apiKey, event)
-}
-
-func sendToUrlWithApiKeyAsync(url string, apiKey string, event Event) error {
-	return instance.sendToUrlWithApiKeyAsync(url, apiKey, event)
+	return instance.sendToUrlWithApiKeyAsync(ApiUrl, apiKey, event)
 }

--- a/apialerts_test.go
+++ b/apialerts_test.go
@@ -6,58 +6,96 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
-
-	"github.com/apialerts/apialerts-go/model"
 )
 
 func TestApiAlertsClient(t *testing.T) {
-	config := model.APIAlertsConfig{
-		Logging: true,
+	config := Config{
 		Timeout: 45 * time.Second,
-		Debug:   false,
+		Debug:   true,
+	}
+	ConfigureWithConfig("test_api_key", config)
+
+	if instance.apiKey != "test_api_key" {
+		t.Errorf("Expected API key to be 'test_api_key', got '%s'", instance.apiKey)
 	}
 
-	client := ApiAlertsClientWithConfig("test_api_key", config)
-
-	if client.ApiKey != "test_api_key" {
-		t.Errorf("Expected API key to be 'test_api_key', got '%s'", client.ApiKey)
+	if instance.config.Timeout != 45*time.Second {
+		t.Errorf("Expected timeout to be 45 seconds, got %v", instance.config.Timeout)
 	}
 
-	if client.Config.Timeout != 45*time.Second {
-		t.Errorf("Expected timeout to be 45 seconds, got %v", client.Config.Timeout)
+	if !instance.config.Debug {
+		t.Errorf("Expected Debug to be false, got %v", instance.config.Debug)
 	}
 }
 
 func TestSetApiKey(t *testing.T) {
-	client := &APIAlertsClient{}
-	client.SetApiKey("new_api_key")
+	Configure("test_api_key")
+	SetApiKey("new_api_key")
 
-	if client.ApiKey != "new_api_key" {
-		t.Errorf("Expected API key to be 'new_api_key', got '%s'", client.ApiKey)
+	if instance.apiKey != "new_api_key" {
+		t.Errorf("Expected API key to be 'new_api_key', got '%s'", instance.apiKey)
 	}
 }
 
 func TestSendAsync(t *testing.T) {
-	config := model.APIAlertsConfig{
-		Logging: true,
-		Timeout: 45 * time.Second,
-		Debug:   true,
-	}
+	server := createTestServer(t)
+	defer server.Close()
 
-	client := ApiAlertsClientWithConfig("test_api_key", config)
+	Configure("test_api_key")
 
-	event := model.APIAlertsEvent{
+	event := Event{
 		Channel: "test_channel",
 		Message: "Test message",
 		Tags:    []string{"tag1", "tag2"},
-		Link:    "http://example.com",
+		Link:    "https://example.com",
 	}
 
-	client.SendAsync(event)
+	err := sendToUrlWithApiKeyAsync(
+		server.URL,
+		"test_api_key",
+		event)
+
+	if err != nil {
+		t.Errorf("Error sending message: %v", err)
+	}
 }
 
 func TestSend(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	Configure("test_api_key")
+
+	event := Event{
+		Channel: "test_channel",
+		Message: "Test message",
+		Tags:    []string{"tag1", "tag2"},
+		Link:    "https://example.com",
+	}
+
+	err := sendToUrlWithApiKeyAsync(
+		server.URL,
+		"test_api_key",
+		event)
+
+	if err != nil {
+		t.Errorf("Error sending message: %v", err)
+	}
+
+	err = sendToUrlWithApiKeyAsync(
+		server.URL,
+		"test_api_key",
+		Event{
+			Channel: "test_channel",
+		})
+
+	if err == nil || err.Error() != "x (apialerts.com) Error: message is required" {
+		t.Errorf("Expected 'message is required' error, got %v", err)
+	}
+}
+
+func createTestServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer test_api_key" {
 			t.Errorf("Expected Authorization header to be 'Bearer test_api_key'")
 		}
@@ -73,7 +111,6 @@ func TestSend(t *testing.T) {
 
 		var payload map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&payload)
-
 		if err != nil {
 			t.Errorf("Error decoding payload: %v", err)
 		}
@@ -84,35 +121,8 @@ func TestSend(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 		err = json.NewEncoder(w).Encode(map[string]string{"workspace": "test_workspace", "channel": "test_channel"})
-
 		if err != nil {
 			t.Errorf("Error encoding response: %v", err)
 		}
 	}))
-	defer server.Close()
-
-	client := ApiAlertsClientWithConfig("test_api_key", defaultConfig)
-
-	err := client.sendToUrlWithApiKey(
-		server.URL,
-		"test_api_key",
-		model.APIAlertsEvent{
-			Channel: "test_channel",
-			Message: "Test message",
-		})
-
-	if err != nil {
-		t.Errorf("Error sending message: %v", err)
-	}
-
-	err = client.sendToUrlWithApiKey(
-		server.URL,
-		"test_api_key",
-		model.APIAlertsEvent{
-			Channel: "test_channel",
-		})
-
-	if err == nil || err.Error() != "x (apialerts.com) Error: message is required" {
-		t.Errorf("Expected 'message is required' error, got %v", err)
-	}
 }

--- a/apialerts_test.go
+++ b/apialerts_test.go
@@ -1,9 +1,6 @@
 package apialerts
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -35,94 +32,4 @@ func TestSetApiKey(t *testing.T) {
 	if instance.apiKey != "new_api_key" {
 		t.Errorf("Expected API key to be 'new_api_key', got '%s'", instance.apiKey)
 	}
-}
-
-func TestSendAsync(t *testing.T) {
-	server := createTestServer(t)
-	defer server.Close()
-
-	Configure("test_api_key")
-
-	event := Event{
-		Channel: "test_channel",
-		Message: "Test message",
-		Tags:    []string{"tag1", "tag2"},
-		Link:    "https://example.com",
-	}
-
-	err := GetInstance().sendToUrlWithApiKeyAsync(
-		server.URL,
-		"test_api_key",
-		event)
-
-	if err != nil {
-		t.Errorf("Error sending message: %v", err)
-	}
-}
-
-func TestSend(t *testing.T) {
-	server := createTestServer(t)
-	defer server.Close()
-
-	Configure("test_api_key")
-
-	event := Event{
-		Channel: "test_channel",
-		Message: "Test message",
-		Tags:    []string{"tag1", "tag2"},
-		Link:    "https://example.com",
-	}
-
-	err := GetInstance().sendToUrlWithApiKeyAsync(
-		server.URL,
-		"test_api_key",
-		event)
-
-	if err != nil {
-		t.Errorf("Error sending message: %v", err)
-	}
-
-	err = GetInstance().sendToUrlWithApiKeyAsync(
-		server.URL,
-		"test_api_key",
-		Event{
-			Channel: "test_channel",
-		})
-
-	if err == nil || err.Error() != "x (apialerts.com) Error: message is required" {
-		t.Errorf("Expected 'message is required' error, got %v", err)
-	}
-}
-
-func createTestServer(t *testing.T) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer test_api_key" {
-			t.Errorf("Expected Authorization header to be 'Bearer test_api_key'")
-		}
-		if r.Header.Get("Content-Type") != "application/json" {
-			t.Errorf("Expected Content-Type header to be 'application/json'")
-		}
-		if r.Header.Get("X-Integration") != "golang" {
-			t.Errorf("Expected X-Integration header to be 'golang'")
-		}
-		if r.Header.Get("X-Version") != IntegrationVersion {
-			t.Errorf("Expected X-Version header to be '%s'", IntegrationVersion)
-		}
-
-		var payload map[string]interface{}
-		err := json.NewDecoder(r.Body).Decode(&payload)
-		if err != nil {
-			t.Errorf("Error decoding payload: %v", err)
-		}
-
-		if payload["message"] != "Test message" {
-			t.Errorf("Expected message to be 'Test message', got '%v'", payload["message"])
-		}
-
-		w.WriteHeader(http.StatusOK)
-		err = json.NewEncoder(w).Encode(map[string]string{"workspace": "test_workspace", "channel": "test_channel"})
-		if err != nil {
-			t.Errorf("Error encoding response: %v", err)
-		}
-	}))
 }

--- a/apialerts_test.go
+++ b/apialerts_test.go
@@ -50,7 +50,7 @@ func TestSendAsync(t *testing.T) {
 		Link:    "https://example.com",
 	}
 
-	err := sendToUrlWithApiKeyAsync(
+	err := GetInstance().sendToUrlWithApiKeyAsync(
 		server.URL,
 		"test_api_key",
 		event)
@@ -73,7 +73,7 @@ func TestSend(t *testing.T) {
 		Link:    "https://example.com",
 	}
 
-	err := sendToUrlWithApiKeyAsync(
+	err := GetInstance().sendToUrlWithApiKeyAsync(
 		server.URL,
 		"test_api_key",
 		event)
@@ -82,7 +82,7 @@ func TestSend(t *testing.T) {
 		t.Errorf("Error sending message: %v", err)
 	}
 
-	err = sendToUrlWithApiKeyAsync(
+	err = GetInstance().sendToUrlWithApiKeyAsync(
 		server.URL,
 		"test_api_key",
 		Event{

--- a/client.go
+++ b/client.go
@@ -1,0 +1,103 @@
+package apialerts
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"time"
+)
+
+type Client struct {
+	apiKey     string
+	config     Config
+	httpClient *http.Client
+}
+
+func initializeClient(apiKey string, config Config) *Client {
+	return &Client{
+		apiKey: apiKey,
+		config: config,
+		httpClient: &http.Client{
+			Timeout: config.Timeout,
+		},
+	}
+}
+
+func (client *Client) sendToUrlWithApiKey(url string, apiKey string, event Event) {
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- client.sendToUrlWithApiKeyAsync(url, apiKey, event)
+	}()
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			log.Printf("x (apialerts.com) Error: %v", err)
+		}
+	case <-time.After(client.config.Timeout):
+		log.Println("x (apialerts.com) Error: Send operation timed out")
+	}
+}
+
+func (client *Client) sendToUrlWithApiKeyAsync(url string, apiKey string, event Event) error {
+	log.Println("x (apialerts.com) Sending alert...")
+	log.Println(apiKey)
+	log.Println(event)
+
+	if apiKey == "" {
+		return errors.New("x (apialerts.com) Error: api key is missing, use SetApiKey() to set it")
+	}
+
+	if event.Message == "" {
+		return errors.New("x (apialerts.com) Error: message is required")
+	}
+
+	payloadBytes, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Integration", IntegrationName)
+	req.Header.Set("X-Version", IntegrationVersion)
+
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("x (apialerts.com) Error closing response body: %v", err)
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var data map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return err
+		}
+		if client.config.Debug {
+			log.Printf("✓ (apialerts.com) Alert sent to %v (%v) successfully.", data["workspace"], data["channel"])
+		}
+		return nil
+	case http.StatusBadRequest:
+		return errors.New("x (apialerts.com) Error: bad request")
+	case http.StatusUnauthorized:
+		return errors.New("x (apialerts.com) Error: unauthorized")
+	case http.StatusForbidden:
+		return errors.New("x (apialerts.com) Error: forbidden")
+	case http.StatusTooManyRequests:
+		return errors.New("x (apialerts.com) Error: rate limit exceeded")
+	default:
+		return errors.New("x (apialerts.com) Error: unknown error")
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,98 @@
+package apialerts
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSendAsync(t *testing.T) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	Configure("test_api_key")
+
+	event := Event{
+		Channel: "test_channel",
+		Message: "Test message",
+		Tags:    []string{"tag1", "tag2"},
+		Link:    "https://example.com",
+	}
+
+	err := GetInstance().sendToUrlWithApiKeyAsync(
+		server.URL,
+		"test_api_key",
+		event)
+
+	if err != nil {
+		t.Errorf("Error sending message: %v", err)
+	}
+}
+
+func TestSend(t *testing.T) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	Configure("test_api_key")
+
+	event := Event{
+		Channel: "test_channel",
+		Message: "Test message",
+		Tags:    []string{"tag1", "tag2"},
+		Link:    "https://example.com",
+	}
+
+	err := GetInstance().sendToUrlWithApiKeyAsync(
+		server.URL,
+		"test_api_key",
+		event)
+
+	if err != nil {
+		t.Errorf("Error sending message: %v", err)
+	}
+
+	err = GetInstance().sendToUrlWithApiKeyAsync(
+		server.URL,
+		"test_api_key",
+		Event{
+			Channel: "test_channel",
+		})
+
+	if err == nil || err.Error() != "x (apialerts.com) Error: message is required" {
+		t.Errorf("Expected 'message is required' error, got %v", err)
+	}
+}
+
+func createTestServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test_api_key" {
+			t.Errorf("Expected Authorization header to be 'Bearer test_api_key'")
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type header to be 'application/json'")
+		}
+		if r.Header.Get("X-Integration") != "golang" {
+			t.Errorf("Expected X-Integration header to be 'golang'")
+		}
+		if r.Header.Get("X-Version") != IntegrationVersion {
+			t.Errorf("Expected X-Version header to be '%s'", IntegrationVersion)
+		}
+
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		if err != nil {
+			t.Errorf("Error decoding payload: %v", err)
+		}
+
+		if payload["message"] != "Test message" {
+			t.Errorf("Expected message to be 'Test message', got '%v'", payload["message"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(map[string]string{"workspace": "test_workspace", "channel": "test_channel"})
+		if err != nil {
+			t.Errorf("Error encoding response: %v", err)
+		}
+	}))
+}

--- a/event.go
+++ b/event.go
@@ -1,6 +1,6 @@
-package model
+package apialerts
 
-type APIAlertsEvent struct {
+type Event struct {
 	Channel string   `json:"channel"`
 	Message string   `json:"message"`
 	Tags    []string `json:"tags"`

--- a/model/config.go
+++ b/model/config.go
@@ -1,9 +1,0 @@
-package model
-
-import "time"
-
-type APIAlertsConfig struct {
-	Logging bool
-	Timeout time.Duration
-	Debug   bool
-}


### PR DESCRIPTION
Refactor the apialerts library as a singleton
 - Rename APIAlertsClient to Client. imports nicer as apialerts.Client in projects
 - Add public function documentation
 - Split out client.go from main file. apialerts.go is the public facing methods
 - Split up tests to client and main files
 - Update tests
 - Add support for the success response 'errors' array as debug logs